### PR TITLE
xUnit環境を追加

### DIFF
--- a/ramenTimer.Tests/UnitTest1.cs
+++ b/ramenTimer.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace ramenTimer.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}

--- a/ramenTimer.Tests/UnitTest1.cs
+++ b/ramenTimer.Tests/UnitTest1.cs
@@ -5,6 +5,7 @@ public class UnitTest1
     [Fact]
     public void Test1()
     {
-
+        var target = new MyClass();
+        Assert.Equal(1, target.MyMethod());
     }
 }

--- a/ramenTimer.Tests/Usings.cs
+++ b/ramenTimer.Tests/Usings.cs
@@ -1,0 +1,1 @@
+﻿global using Xunit;

--- a/ramenTimer.Tests/ramenTimer.Tests.csproj
+++ b/ramenTimer.Tests/ramenTimer.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/ramenTimer.Tests/ramenTimer.Tests.csproj
+++ b/ramenTimer.Tests/ramenTimer.Tests.csproj
@@ -22,4 +22,7 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ramenTimer\ramenTimer.csproj" />
+  </ItemGroup>
 </Project>

--- a/ramenTimer.sln
+++ b/ramenTimer.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31611.283
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ramenTimer", "ramenTimer\ramenTimer.csproj", "{8EB8CC93-F7C7-4DDF-9812-87F31F97355E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ramenTimer.Tests", "ramenTimer.Tests\ramenTimer.Tests.csproj", "{D1330433-8B91-436B-A957-B1966478A6FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		{8EB8CC93-F7C7-4DDF-9812-87F31F97355E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8EB8CC93-F7C7-4DDF-9812-87F31F97355E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8EB8CC93-F7C7-4DDF-9812-87F31F97355E}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{D1330433-8B91-436B-A957-B1966478A6FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1330433-8B91-436B-A957-B1966478A6FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1330433-8B91-436B-A957-B1966478A6FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1330433-8B91-436B-A957-B1966478A6FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ramenTimer/MyClass.cs
+++ b/ramenTimer/MyClass.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace ramenTimer
+{
+	public class MyClass
+	{
+
+		public int MyMethod()
+		{
+			return 1;
+		}
+	}
+}
+

--- a/ramenTimer/ramenTimer.csproj
+++ b/ramenTimer/ramenTimer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst;net7.0</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->

--- a/ramenTimer/ramenTimer.csproj
+++ b/ramenTimer/ramenTimer.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
-		<OutputType>Exe</OutputType>
+		<OutputType Condition="'$(TargetFramework)' != 'net7.0'">Exe</OutputType>
 		<RootNamespace>ramenTimer</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>


### PR DESCRIPTION
## 関連課題

- #1 

## 確認事項

- サンプルで追加したテストが実行できた
- Mac、iOS、Androidデバイスでデバッグが実行できた

## 追加手順

Visual Studio 2022 for Mac (v17.5.4) では単純に追加できなかったため、次のWikiに手順を整理

- [.NET MAUI (.NET7.0) に xUnitプロジェクトを追加](https://github.com/msrx9/ramenTimer/wiki/AddxUnit)